### PR TITLE
Move magic-launch to remote part

### DIFF
--- a/snap/local/launchers/magic-launch
+++ b/snap/local/launchers/magic-launch
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Launcher to make libmagic work, refer file(1), magic(5) manual pages
-export MAGIC="${SNAP}"/usr/share/misc/magic
-exec "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,6 +112,9 @@ parts:
 
   classic-launch:
 
+  # Remote part for fixing libmagic applications
+  magic-launch:
+
   # Remote part for fixing the glibc locales(and gnu gettext I18N support)
   # This part is only required for non GUI apps that don't uses the desktop-launch launchers
   locales-launch:


### PR DESCRIPTION
This patch uses the remote part implementation of the `magic-launch` launcher.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>