### PR TITLE
Use dialog(1) for nanorc workaround prompt

### DIFF
--- a/snap/local/launchers/nano-launch
+++ b/snap/local/launchers/nano-launch
@@ -7,6 +7,9 @@ set \
 	-o nounset \
 	-o pipefail
 
+declare \
+    launcher_title='The (UNOFFICIAL) GNU nano Snap Helper'
+
 ## Support user's default nano config when available
 ## Refer rcfile.c
 declare \
@@ -48,27 +51,17 @@ if test "${HOME}" != "${real_home_dir}"; then
     # Show warning if user do have a config file but not in the accessible location
     if test -v user_nanorc; then
         if ! test -e "${snap_nanorc}"; then
-            printf -- \
-                "nano-launch: It appears that you have a nanorc file in your home directory, however due to snapd's security confinement it is not accessible by the snap.\\n" \
-                >&2
-            # Intentionally print not expanded expression
-            # shellcheck disable=SC2016
-            printf -- \
-                'nano-launch: If you wish to use it you have to create a hardlink manually by running the `ln %s %s` command in a terminal.\n' \
-                "${user_nanorc}" \
-                "${snap_nanorc}" \
-                >&2
-            # Intentionally print not expanded expression
-            # shellcheck disable=SC2016
-            printf -- \
-                'nano-launch: To silent this warning without linking create a blank file at %s.\n' \
-                "${snap_nanorc}" \
-                >&2
-
-            printf -- \
-                '\nPress Enter to continue:' \
-                >&2
-            read placeholder
+            # Disable mouse support for select-copy-paste convenience
+            dialog \
+                --title "${launcher_title}" \
+                --no-mouse \
+                --msgbox "$(
+                    echo -e \
+                        "It appears that you have a nanorc file in your home directory, however due to snapd's security confinement it is not accessible by the snap.\\n\\n" \
+                        "If you wish to use it you have to create a hardlink manually by running the following command in a terminal:\\n\\n" \
+                        "ln ${user_nanorc} ${snap_nanorc}\\n\\n" \
+                        "To silent this warning create a blank file at ${snap_nanorc}."
+                )" 0 0 # autosized
         fi
     fi
     export XDG_CONFIG_HOME="${SNAP_USER_COMMON}"/.config

--- a/snap/local/launchers/nano-launch
+++ b/snap/local/launchers/nano-launch
@@ -57,10 +57,10 @@ if test "${HOME}" != "${real_home_dir}"; then
                 --no-mouse \
                 --msgbox "$(
                     echo -e \
-                        "It appears that you have a nanorc file in your home directory, however due to snapd's security confinement it is not accessible by the snap.\\n\\n" \
-                        "If you wish to use it you have to create a hardlink manually by running the following command in a terminal:\\n\\n" \
-                        "ln ${user_nanorc} ${snap_nanorc}\\n\\n" \
-                        "To silent this warning create a blank file at ${snap_nanorc}."
+                        "It appears that you have a nanorc file in your home directory, however due to snapd's security confinement it is not accessible by the snap." \
+                        "\\n\\nIf you wish to use it you have to create a hardlink manually by running the following command in a terminal:" \
+                        "\\n\\nln ${user_nanorc} ${snap_nanorc}" \
+                        "\\n\\nTo silent this warning create a blank file at ${snap_nanorc}."
                 )" 0 0 # autosized
         fi
     fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,11 +57,12 @@ plugs:
 apps:
   nano:
     command: >
-      bin/nano-launch
-      "${SNAP}"/bin/workaround-snap-arch-triplet-launch
+      bin/workaround-snap-arch-triplet-launch
       "${SNAP}"/bin/classic-launch
       "${SNAP}"/bin/locales-launch
       "${SNAP}"/bin/magic-launch
+      "${SNAP}"/bin/ncurses-launch
+      "${SNAP}"/bin/nano-launch
       "${SNAP}"/bin/nano
     environment:
       # Fix "Error opening terminal: xterm-256color." error in classic confinement
@@ -70,11 +71,12 @@ apps:
 
   rnano:
     command: >
-      bin/nano-launch
-      "${SNAP}"/bin/workaround-snap-arch-triplet-launch
+      bin/workaround-snap-arch-triplet-launch
       "${SNAP}"/bin/classic-launch
       "${SNAP}"/bin/locales-launch
       "${SNAP}"/bin/magic-launch
+      "${SNAP}"/bin/ncurses-launch
+      "${SNAP}"/bin/nano-launch
       "${SNAP}"/bin/rnano
     environment:
       # Fix "Error opening terminal: xterm-256color." error in classic confinement
@@ -97,6 +99,8 @@ parts:
     plugin: dump
     organize:
       '*-launch': bin/
+    stage-packages:
+    - dialog
 
   # Program patches to solve issues that can't be solved by tweaking in runtime
   #patches:


### PR DESCRIPTION
```
$ nano
nano-launch: It appears that you have a nanorc file in your home directory, however due to snapd's security confinement it is not accessible by the snap.
nano-launch: If you wish to use it you have to create a hardlink manually by running the `ln /home/buo-ren/.nanorc /home/buo-ren/snap/nano/common/.config/nano/nanorc` command in a terminal.
nano-launch: To silent this warning without linking create a blank file at /home/buo-ren/snap/nano/common/.config/nano/nanorc.

Press Enter to continue:
```

The previous prompt is not pretty, let's make it better.

This patch re-implements the prompt using dialog(1), to draw a pretty dialog box before launching nano(also a curses application).

![default](https://user-images.githubusercontent.com/13408130/49769551-988b2400-fd1b-11e8-9e6b-3494f4329eb8.png)

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>