### PR TITLE
Fix implicit source `.` problem

### DIFF
--- a/snap/local/utilities/parts-nano-override-pull.bash
+++ b/snap/local/utilities/parts-nano-override-pull.bash
@@ -13,16 +13,12 @@ init(){
 	local \
 		all_upstream_release_tags \
 		checkout_mode=tip \
-		clone_depth=100 \
 		last_upstream_release_version \
 		last_snapped_release_version \
 		upstream_version \
 		packaging_revision
 
-	git clone \
-		--depth="${clone_depth}" \
-		git://git.savannah.gnu.org/nano.git \
-		.
+	snapcraftctl pull
 
 	if \
 		! \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -130,6 +130,9 @@ parts:
     after:
     - utilities
 
+    source: git://git.savannah.gnu.org/nano.git
+    source-depth: 100
+
     override-pull: '"${SNAPCRAFT_STAGE}"/assets/utilities/parts-nano-override-pull.bash'
 
     plugin: autotools


### PR DESCRIPTION
Refer-to: Bug #1807555 “Snapcraft forgot adopt-info is provided by
`snapcr...” : Bugs : Snapcraft
<https://bugs.launchpad.net/snapcraft/+bug/1807555>
Refer-to: Bug #1776807 “Part's without `source` key has an implicit
source...” : Bugs : Snapcraft
<https://bugs.launchpad.net/snapcraft/+bug/1776807
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>