### PR TITLE
Fix build failure due to shallow source-depth

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -133,8 +133,6 @@ parts:
     - utilities
 
     source: git://git.savannah.gnu.org/nano.git
-    source-depth: 100
-
     override-pull: '"${SNAPCRAFT_STAGE}"/assets/utilities/parts-nano-override-pull.bash'
 
     plugin: autotools


### PR DESCRIPTION
Previously the source-depth of the nano part is limited to 100 to minimize clone time, this is no longer required now and is removed in this patch to ensure that the build won't fail due to missing release tags in the upstream repository (to generate proper snap version string).

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>