### PR TITLE
Workaround Snapcraft bug #1807553

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,7 @@ parts:
     source: snap/local/utilities
     plugin: dump
     organize:
-      '*': assets/utilities/
+      '*': utilities/
     prime:
     - -*
 
@@ -126,7 +126,7 @@ parts:
     source: snap/local/rcfiles
     plugin: dump
     organize:
-      '*': assets/rcfiles/
+      '*': rcfiles/
 
   nano:
     after:
@@ -135,12 +135,12 @@ parts:
     source: git://git.savannah.gnu.org/nano.git
     source-depth: 100
 
-    override-pull: '"${SNAPCRAFT_STAGE}"/assets/utilities/parts-nano-override-pull.bash'
+    override-pull: '"${SNAPCRAFT_STAGE}"/utilities/parts-nano-override-pull.bash'
 
     plugin: autotools
     configflags:
     - --datarootdir=/snap/$SNAPCRAFT_PROJECT_NAME/current/share
-    - --sysconfdir=/snap/$SNAPCRAFT_PROJECT_NAME/current/assets/rcfiles
+    - --sysconfdir=/snap/$SNAPCRAFT_PROJECT_NAME/current/rcfiles
     build-packages:
     - gettext
     - groff


### PR DESCRIPTION
Snapcraft don't like files organizing into same directories :(.

Refer-to: Bug #1807553 “Snapcraft crashes after changing `dump` part's source content” : Bugs : Snapcraft
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>