### PR TITLE
Fix Multipass/LXD compatibility

### DIFF
--- a/snap/local/utilities/parts-nano-override-pull.bash
+++ b/snap/local/utilities/parts-nano-override-pull.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # This scriptlet implements the workflow of the snaps owned by the snapcrafters organization
 # https://forum.snapcraft.io/t/autopublishing-of-snapcrafters-organizations-snaps-how/7954/2
-# 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com> © 2018
+# 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com> © 2020
 
 set \
 	-o errexit \
@@ -74,7 +74,7 @@ init(){
 
 	packaging_revision="$(
 		git \
-			-C .. \
+			-C "${SNAPCRAFT_PROJECT_DIR}" \
 			describe \
 			--abbrev=4 \
 			--always \


### PR DESCRIPTION
The project directory is now reside at /root/project in the build environment,
use the new SNAPACRAFT_PROJECT_DIR environment variable to fix compatibility.

Refer-to: Unable to determine project version info in multipass build environment - snapcraft - snapcraft.io <https://forum.snapcraft.io/t/unable-to-determine-project-version-info-in-multipass-build-environment/10416>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>