### PR TITLE
Remove leading path on filename

### DIFF
--- a/.github/workflows/build-prs.yaml
+++ b/.github/workflows/build-prs.yaml
@@ -27,7 +27,7 @@ jobs:
           --platform "${{ matrix.architecture }}" \
           diddledan/snapcraft:core snap run snapcraft
 
-          SNAPFILE="$(find "$GITHUB_WORKSPACE" -maxdepth 1 -type f -name "*.snap" | head -n1)"
+          SNAPFILE="$(find "$GITHUB_WORKSPACE" -maxdepth 1 -type f -name "*.snap" | head -n1 | sed -Ee "s|^$GITHUB_WORKSPACE/?||")"
           sudo chown "$(id -u)":"$(id -g)" "$SNAPFILE"
           echo ::set-output name=snap::"$SNAPFILE"
     - name: Review


### PR DESCRIPTION
Upload Assets is complaining about the leading path gained from running `find`. This removes it.