### PR TITLE
Fix "Error opening terminal: xterm-256color." error when launching

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -110,12 +110,14 @@ parts:
     - libc-bin
     - locales
 
-  # Launcher for fixing ncurses applications
-  # https://forum.snapcraft.io/t/the-ncurses-launch-launcher-stage-snap/10444
+  # The ncurses-launch launcher: Fix ncurses applications in the snap runtime - doc - snapcraft.io
+  # https://forum.snapcraft.io/t/the-ncurses-launch-launcher-fix-ncurses-applications-in-the-snap-runtime/10444
   ncurses-launch:
-    plugin: nil
-    stage-snaps:
-    - ncurses-launch
+    source: https://github.com/Lin-Buo-Ren/ncurses-launch.git
+    source-tag: v1.0.0
+    stage-packages:
+      - ncurses-base
+    plugin: dump
 
   # A minimal nanorc for this snap
   rcfiles:


### PR DESCRIPTION
The snap lacks files from the ncurses-base package, which was not
shipped in the snap nor the ncurses-launch stage snap, causing the
error.

This patch also migrates to the new implementation of ncurses-launch
launcher, which dumps the source repository instead of using the built
stage-snap, which is no longer unsupported.

Fixes #23.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>