### PR TITLE
chore: Implement i386 support obsoletion notice

### DIFF
--- a/snap/local/launchers/nano-launch
+++ b/snap/local/launchers/nano-launch
@@ -28,6 +28,28 @@ real_home_dir="$(
         --fields=6
 )"
 
+i386_obsoletion_disable_marker_file="${SNAP_USER_COMMON}/.20250823-i386-obsoletion-notice-disabled.marker"
+if test "${SNAP_ARCH}" == i386 \
+    && ! test -e "${i386_obsoletion_disable_marker_file}"; then
+    dialog \
+        --title 'i386 architecture support obsoletion notice' \
+        --no-mouse \
+        --no-collapse \
+        --msgbox "$(
+            printf 'We would like to inform you that we are no longer be able to support the i386 architecture for this snap at the moment.\n\n'
+
+            printf 'Refer to the following issue for more information:\n\n'
+            printf '\tObsoleting i386 support · Issue #32 · snapcrafters/nano\n'
+            printf '\thttps://github.com/snapcrafters/nano/issues/32\n\n'
+
+            printf 'You may continue using it but we recommend switching to another installation to stay updated and secured in the meantime.\n\n'
+
+            printf 'To disable this notice, run the following command in a terminal:\n\n'
+
+            printf '\ttouch %s\n' "${i386_obsoletion_disable_marker_file}"
+        )" 0 0 # autosized
+fi
+
 # Don't do anything in classic confinement
 if test "${HOME}" != "${real_home_dir}"; then
     user_nanorc_homedir="${real_home_dir}"/.nanorc

--- a/snap/local/utilities/parts-nano-override-pull.bash
+++ b/snap/local/utilities/parts-nano-override-pull.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # This scriptlet implements the workflow of the snaps owned by the snapcrafters organization
 # https://forum.snapcraft.io/t/autopublishing-of-snapcrafters-organizations-snaps-how/7954/2
-# 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com> © 2020
+# 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com> © 2025
 
 set \
 	-o errexit \
@@ -12,7 +12,6 @@ set \
 init(){
 	local \
 		all_upstream_release_tags \
-		checkout_mode=tip \
 		last_upstream_release_version \
 		last_snapped_release_version \
 		upstream_version \
@@ -52,9 +51,7 @@ init(){
 	)"
 
 	# If the latest tag from the upstream project has not been released to the stable channel, build that tag instead of the development snapshot and publish it in the edge channel.
-	if [ "${last_upstream_release_version}" != "${last_snapped_release_version}" ] \
-		|| [ "${checkout_mode}" = release ]; then
-		checkout_mode=release
+	if [ "${last_upstream_release_version}" != "${last_snapped_release_version}" ]; then
 		git checkout v"${last_upstream_release_version}"
 	fi
 

--- a/snap/local/utilities/parts-nano-override-pull.bash
+++ b/snap/local/utilities/parts-nano-override-pull.bash
@@ -3,6 +3,9 @@
 # https://forum.snapcraft.io/t/autopublishing-of-snapcrafters-organizations-snaps-how/7954/2
 # 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com> © 2025
 
+# Force the version to a specific upstream release version(without the v prefix)
+FORCE_VERSION="${FORCE_VERSION:-}"
+
 set \
 	-o errexit \
 	-o errtrace \
@@ -50,9 +53,13 @@ init(){
 			| cut --delimiter=+ --fields=1
 	)"
 
-	# If the latest tag from the upstream project has not been released to the stable channel, build that tag instead of the development snapshot and publish it in the edge channel.
-	if [ "${last_upstream_release_version}" != "${last_snapped_release_version}" ]; then
-		git checkout v"${last_upstream_release_version}"
+	if test -n "${FORCE_VERSION}"; then
+		git checkout v"${FORCE_VERSION}"
+	else
+		# If the latest tag from the upstream project has not been released to the stable channel, build that tag instead of the development snapshot and publish it in the edge channel.
+		if [ "${last_upstream_release_version}" != "${last_snapped_release_version}" ]; then
+			git checkout v"${last_upstream_release_version}"
+		fi
 	fi
 
 	unset \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,7 +126,7 @@ parts:
   nano:
     after: [utilities]
     source: git://git.savannah.gnu.org/nano.git
-    override-pull: '"${SNAPCRAFT_STAGE}"/utilities/parts-nano-override-pull.bash'
+    override-pull: 'FORCE_VERSION=7.2 "${SNAPCRAFT_STAGE}"/utilities/parts-nano-override-pull.bash'
     plugin: autotools
     configflags:
     - --datarootdir=/snap/$SNAPCRAFT_PROJECT_NAME/current/share


### PR DESCRIPTION
This patch implements the necessary changes to build a revision that
ships the i386 architecture support obsoletion notice.

Fixes [#32](https://github.com/snapcrafters/nano/issues/32).

Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>