### PR TITLE
fix(build-prs): Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-prs.yaml
+++ b/.github/workflows/build-prs.yaml
@@ -29,7 +29,7 @@ jobs:
         snap: ${{ steps.build.outputs.snap }}
         isClassic: 'true'
     - name: Save snap
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.architecture }}.snap
         path: ${{ steps.build.outputs.snap }}


### PR DESCRIPTION
This pull request fixes the following error message:

```text
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

This won't make the workflow work, though, as another error surfaced after this one:

```text
Run diddlesnaps/snapcraft-multiarch-action@v1
Building Snapcraft project in "."...
/usr/bin/bash -c echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
{"experimental":true}
/usr/bin/sudo systemctl restart docker
Error: Your build specified 'core' as the base, but your system is using cgroups v2. 'core' does not support cgroups v2. Please use 'core18' or later or an older Linux distribution that uses CGroups version 1 instead.
```