### PR TITLE
fix(git): Don't track snapcraft remote-build log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 
 /*.snap
 /*_source.tar.bz2
+
+# Don't track snapcraft remote-build log files
+/snapcraft-*.txt


### PR DESCRIPTION
Reduce git status clutter.