### PR TITLE
fix: add platforms block to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,11 @@ base: core24
 confinement: classic
 grade: stable
 
+platforms:
+  amd64:
+  arm64:
+  armhf:
+
 apps:
   nano:
     command: usr/local/bin/nano


### PR DESCRIPTION
Fixes the release workflow failure in https://github.com/snapcrafters/nano/actions/runs/26455827425.

## Root cause

The `get-architectures` CI action reads `platforms:` (or `architectures:`) from `snap/snapcraft.yaml` to construct the build matrix. Without that block the matrix is empty, the `release` job is skipped entirely, and `call-for-testing` is consequently skipped too.

## Fix

Add a `platforms:` block covering the three architectures nano has historically supported: `amd64`, `arm64`, `armhf`.