### PR TITLE
fix: provide token to nano version sync

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -9,11 +9,13 @@ concurrency:
 jobs:
   sync:
     name: 🔄 Sync version with upstream
+    environment: "Candidate Branch"
     runs-on: ubuntu-latest
     steps:
       - name: 🔄 Sync version with upstream
         uses: snapcrafters/ci/sync-version@main
         with:
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
             VERSION=$(curl -sSL "https://ftp.gnu.org/gnu/nano/" \
               | grep -oP 'nano-[\d.]+\.tar\.gz' \
@@ -21,4 +23,4 @@ jobs:
               | tail -1 \
               | grep -oP '[\d.]+(?=\.tar\.gz)')
             sed -i "s/^version: .*/version: \"${VERSION}\"/" snap/snapcraft.yaml
-            sed -i "s/^    source-tag: .*/    source-tag: v${VERSION}/" snap/snapcraft.yaml
+            sed -i "/^  nano:/,/^  [^ ]/ s/^    source-tag: .*/    source-tag: v${VERSION}/" snap/snapcraft.yaml


### PR DESCRIPTION
This fixes the failing Nano sync-version workflow.

Source workflow failure:
https://github.com/snapcrafters/nano/actions/runs/26952512951

Failure evidence:
- The failed run stops before executing the update script with `Input required and not supplied: token`.
- The runner log shows the workflow used `snapcrafters/ci/sync-version@main` without a `token:` input.
- The repository has a `Candidate Branch` environment and `SNAPCRAFTERS_BOT_COMMIT` is present there.
- The Discord and Signal update workflows both use `environment: "Candidate Branch"` and `token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}` for the same shared sync-version action.

Changes:
- Add `environment: "Candidate Branch"` to the sync job.
- Pass `token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}` to `snapcrafters/ci/sync-version@main`.
- Tighten the update script so only the `parts.nano.source-tag` is updated, avoiding accidental changes to the unrelated `ncurses-launch` source tag.

Verification:
- Parsed `.github/workflows/sync-version-with-upstream.yml` as YAML and asserted the token/environment are present.
- Simulated a version bump to confirm only the Nano source tag changes while `ncurses-launch` stays at `v1.0.0`.
- Confirmed the `Candidate Branch` environment exists and contains `SNAPCRAFTERS_BOT_COMMIT`.
- Commit is signed.

@jnsgruk please review.
