### PR TITLE
docs: add CI workflow badges [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 <a href="https://snapcraft.io/nano">
   <img alt="enrol me" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
 </a>
+<br />
+<a href="https://github.com/snapcrafters/nano/actions/workflows/sync-version-with-upstream.yml"><img src="https://github.com/snapcrafters/nano/actions/workflows/sync-version-with-upstream.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/nano/actions/workflows/release-to-candidate.yml"><img src="https://github.com/snapcrafters/nano/actions/workflows/release-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/nano/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/nano/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </p>
 
 ## Install


### PR DESCRIPTION
## Summary
- Adds README badges for the standard Snapcrafters CI workflows.
- Keeps the badges aligned with the existing canonical workflow filenames on `candidate`.

## Verification
- `git diff --check`
- Confirmed the workflow files exist on `candidate`: `sync-version-with-upstream.yml`, `release-to-candidate.yml`, and `promote-to-stable.yml`.
- Scanned Snapcrafters repositories/default branches plus tokenator-declared track branches for standard CI workflows without README badges; only `nano` and `snap-repo-template` matched.

@jnsgruk please review.
